### PR TITLE
Update Mapbox API

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -77,13 +77,13 @@ initMap = (restaurants) => {
           zoom: 12,
           scrollWheelZoom: false
         });
-    L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.jpg70?access_token={mapboxToken}', {
-      mapboxToken: topSecretMapboxToken, //be sure to set a value for this in js/.secrets.js
+    L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
+      accessToken: topSecretMapboxToken, //be sure to set a value for this in js/.secrets.js
       maxZoom: 18,
-      attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
-        '<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-        'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-      id: 'mapbox.streets'
+      tileSize: 512,
+      zoomOffset: -1,
+      attribution: '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>',
+      id: 'mapbox/streets-v11'
     }).addTo(newMap);
     mapDiv.classList.remove("offline") // set map div class to reflect online status
   }

--- a/js/restaurant_info.js
+++ b/js/restaurant_info.js
@@ -30,13 +30,13 @@ initMap = () => {
             zoom: 16,
             scrollWheelZoom: false
           });
-          L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.jpg70?access_token={mapboxToken}', {
-            mapboxToken: topSecretMapboxToken, //be sure to set a value for this in js/.secrets.js
+          L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
+            accessToken: topSecretMapboxToken, //be sure to set a value for this in js/.secrets.js
             maxZoom: 18,
-            attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
-              '<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-              'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-            id: 'mapbox.streets'
+            tileSize: 512,
+            zoomOffset: -1,
+            attribution: '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>',
+            id: 'mapbox/streets-v11'
           }).addTo(newMap);
           mapDiv.classList.remove("offline") // set map div class to reflect online status
         } // end if navigator is online


### PR DESCRIPTION
Update from classic (deprecated) to modern Static Tiles API.
https://blog.mapbox.com/deprecating-studio-classic-styles-d8892ac38cb4
https://docs.mapbox.com/help/troubleshooting/migrate-legacy-static-tiles-api/?/=blog&utm_source=mapbox-blog&utm_campaign=blog%7Cmapbox-blog%7Cdoc-migrate-static%7Cdeprecating-studio-classic-styles-d8892ac38cb4-20-03&utm_term=doc-migrate-static&utm_content=deprecating-studio-classic-styles-d8892ac38cb4